### PR TITLE
#26 example showing lualatex functionality

### DIFF
--- a/examples/9-withluatex/build.gradle
+++ b/examples/9-withluatex/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath group: 'com.github.csabasulyok', name: 'gradle-latex', version: '2.0-SNAPSHOT'
+    }
+}
+
+apply plugin: 'latex'
+
+latex {
+    // overwrite pdfCommand parameter
+    tex(tex: 'document.tex',
+        pdfCommand: 'lualatex')
+}

--- a/examples/9-withluatex/document.tex
+++ b/examples/9-withluatex/document.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage{luacode}
+
+\begin{document}
+A random number:
+\begin{luacode}
+  tex.print(math.random())
+\end{luacode}
+\end{document}


### PR DESCRIPTION
The changes for #31 (xetex support) are applicable for luatex support. This example shows the principal functionality.